### PR TITLE
Added optional argument --resultCsv, which allows to write benchmark …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 .svn
 build
 target
+dependency-reduced-pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,19 @@
         <artifactId>findbugs-maven-plugin</artifactId>
         <version>3.0.1</version>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.4.3</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
   <packaging>jar</packaging>
@@ -61,6 +74,11 @@
       <artifactId>slf4j-log4j12</artifactId>
       <version>1.7.14</version>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-csv</artifactId>
+      <version>2.2.3</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
* Added optional argument --resultCsv, which allows to write benchmark results to a CSV file
* Added optional argument --resultNote, which allows to "tag" a benchmark result with a custom note within a result file